### PR TITLE
install.sh simplification & readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ This chart requires that your cluster has loadbalancing service.
 
 - Kuadrant-operator
 - Red Hat cert-manager
-- Istio provider (one of)
-  - Sail operator
-  - Openshift service mesh v2
+- Istio provider
   - Openshift service mesh v3
 - Gateway API
 
-If you choose to deploy testsuite environment by setting `tools.enabled` to true:
+If you choose to deploy testsuite:
 
 - RH Keycloak
 - Jaeger
@@ -21,29 +19,27 @@ If you choose to deploy testsuite environment by setting `tools.enabled` to true
 
 # How to run
 
-1. Set up values.yaml
-2. Login to your cluster.
+1. Set up values.yaml and/or `INSTALL_RHCL_GA` environment variable
+2. Login to your cluster
 3. Run:
 ```sh
 ./install.sh
 ```
 4. Enjoy
+5. Cleanup: `./uninstall.sh`
 
-## Testsuite deploy and Environment variables
+Note: If you want to install current RHCL GA just set `INSTALL_RHCL_GA` to "true" and use the helper `./install.sh` script. It overrides certain values from values.yaml so that current RHCL GA is installed. It is not needed to modify values.yaml manually in such a case.
 
-If you want testsuite environment create additionalManifests.yaml with list of DNS provider credentials and Letsencrypt issuer. More info about required objects see [testsuite wiki](https://github.com/Kuadrant/testsuite/wiki/Guide-to-prepare-Openshift-cluster-to-run-testsuite)
+## Testsuite deploy
+
+If you want an environment ready for running [Kuadrant testsuite](https://github.com/Kuadrant/testsuite) create additionalManifests.yaml with list of DNS provider credentials and Letsencrypt issuer. More info about required objects see [testsuite wiki](https://github.com/Kuadrant/testsuite/wiki/Guide-to-prepare-Openshift-cluster-to-run-testsuite)
 Look at example-additionalManifests.yaml
 
-Set env variables and run `./testsuite.sh -t`
-
-Env vars:
-- IMAGE sets `kuadrant.indexImage` and defines image of Kuadrant operator, by default it sets today nightly
-- CHANNEL sets `kuadrant.channel` and defines channel of deployed Kuadrant, by default it sets 'preview'
-- DEPLOY_TESTSUITE sets `tools.enabled` and defines if to deploy testsuite environment, by default it sets true
+Use `-t` flag to get Kuadrant testsuite dependencies installed: `./install.sh -t`. It sets `tools.enabled` to true and makes Helm consume additional values from additionalManifests.yaml.
 
 ## Manual helm
 
-If you do not want to use provided `./install.sh`
+If you do not want to use helper `./install.sh` (and `./uninstall.sh`) script:
 
 1. Install Operators
 ```sh
@@ -63,7 +59,7 @@ $ ./install.sh
 Installing operators
 Error: INSTALLATION FAILED: cannot re-use a name that is still in use
 ```
-To fix this execute `helm uninstall kuadrant-operators`
+To fix this execute `helm uninstall kuadrant-operators`. Similarly if the error shows up during installing instances: `helm uninstall kuadrant-instances`.
 
 ## Unable to continue with install
 
@@ -73,3 +69,10 @@ Installing operators
 Error: INSTALLATION FAILED: Unable to continue with install: CustomResourceDefinition "gatewayclasses.gateway.networking.k8s.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "kuadrant-operators"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "default"
 ```
 This happens if there are some leftovers there on a cluster. Typically the Kuadrant had been installed on the cluster previously not using Helm. To overcome such issues everything that Helm creates needs to be removed prior to installing via Helm. For this particular error the Gateway API CRDs needed to be removed.
+
+## Last Resort
+If there are not any leftovers from previous installations and the Helm install/uninstall is still failing, the "Helm internal stuff" needs to be cleared up as well.
+
+`helm ls -a` - to see if there is some Helm release on the cluster.
+
+If there is, one needs to remove the "Helm" secret from `default` namespace. The secret name looks similar to `sh.helm.release.v1.kuadrant-operators.v1`. Once removed (and no leftovers are indeed on the cluster) the Helm install/uninstall starts working as expected.

--- a/install.sh
+++ b/install.sh
@@ -1,38 +1,24 @@
 #!/bin/bash
-# Quick script to run helm
+# Quick script to run Helm
 
 cd "$(dirname "$0")" || exit 1
 
-IMAGE="${IMAGE:-quay.io/kuadrant/kuadrant-operator-catalog:nightly-$(date +%d-%m-%Y)}"
-CHANNEL="${CHANNEL:-preview}"
-DEPLOY_TESTSUITE="${DEPLOY_TESTSUITE:-true}"
+additional_flags=''
 
-if [ "$1" = "-t" ]; then
-    echo "Installing channel $CHANNEL with image: $IMAGE"
-    echo "Testsuite deploy: $DEPLOY_TESTSUITE"
-    echo "---Installing operators---" && \
-    helm install \
-      --values values.yaml \
-      --values additionalManifests.yaml \
-      --set kuadrant.indexImage="$IMAGE" \
-      --set kuadrant.channel="$CHANNEL" \
-      --set tools.enabled="$DEPLOY_TESTSUITE" \
-      --wait kuadrant-operators operators/ && \
-    echo "--Installing instances---" && \
-    helm install \
-      --values values.yaml \
-      --values additionalManifests.yaml \
-      --set kuadrant.indexImage="$IMAGE" \
-      --set kuadrant.channel="$CHANNEL" \
-      --set tools.enabled="$DEPLOY_TESTSUITE" \
-      --wait \
-      kuadrant-instances instances/ && \
-    echo "Success!"
-else
-    echo "Using defaults from values.yaml"
-    echo "Installing operators" && \
-    helm install --values values.yaml --wait kuadrant-operators operators/ && \
-    echo "Installing instances" && \
-    helm install --values values.yaml --wait kuadrant-instances instances/ && \
-    echo "Success!"
+if [[ "$1" == "-t" ]]; then
+    additional_flags+=" --values additionalManifests.yaml --set tools.enabled=true"
 fi
+
+if [[ "$INSTALL_RHCL_GA" == "true" ]]; then
+    additional_flags+=" --set kuadrant.indexImage='' --set kuadrant.operatorName=rhcl-operator --set kuadrant.channel=stable"
+fi
+
+echo "---Installing operators---"
+helm_cmd="helm install --values values.yaml $additional_flags --wait kuadrant-operators operators/"
+eval "$helm_cmd"
+
+echo "--Installing instances---"
+helm_cmd="helm install --values values.yaml $additional_flags --wait kuadrant-instances instances/"
+eval "$helm_cmd"
+
+echo "Success!"

--- a/operators/templates/kuadrant/02-catalogsource.yaml
+++ b/operators/templates/kuadrant/02-catalogsource.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kuadrant.indexImage }}
+{{- if and (.Values.kuadrant.indexImage) (ne .Values.kuadrant.indexImage "") }}
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -4,9 +4,9 @@ kuadrant:
   namespace: kuadrant-system
   # OLM index image to use for kuadrant deployment (creates catalogsource in openshift-marketplace namespace)
   # ; if left empty it uses official released redhat-operators catalogsource in openshift-marketplace namespace
-  indexImage: 'quay.io/kuadrant/kuadrant-operator-catalog:v0.11.0'
-  operatorName: kuadrant-operator  # rhcl-operator if installing downstream
-  channel: stable  # can be either 'preview' for nightly builds or 'stable' for release builds
+  indexImage: 'quay.io/kuadrant/kuadrant-operator-catalog:v1.0.2' # leave empty for donwstream GA, example value for upstream: 'quay.io/kuadrant/kuadrant-operator-catalog:v1.0.2'
+  operatorName: kuadrant-operator  # 'kuadrant-operator' or 'rhcl-operator' if installing downstream
+  channel: stable  # can be either 'preview' for nightly builds and release candidates or 'stable' for release builds
 
 gatewayAPI:
   version: v1.1.0  # v1.0.0, v1.1.0 available
@@ -25,7 +25,7 @@ istio:
 certManager:
   operator:
     channel: stable-v1
-    startingCSV: cert-manager-operator.v1.14.0
+    startingCSV: cert-manager-operator.v1.15.0
     installPlanApproval: Automatic  # if set to Manual InstallPlan has to be approved manually
 
 tools:
@@ -34,11 +34,11 @@ tools:
   jaeger:
     image: quay.io/jaegertracing/all-in-one
   mockserver:
-    image: quay.io/mganisin/mockserver:latest
+    image: quay.io/trepel/mockserver:mganisin
   keycloak:
     operator:
       channel: stable-v26
-      startingCSV: rhbk-operator.v26.0.5-opr.1
+      startingCSV: rhbk-operator.v26.0.10-opr.1
       installPlanApproval: Automatic  # if set to Manual InstallPlan has to be approved manually
     database:
       image: quay.io/sclorg/postgresql-16-c10s


### PR DESCRIPTION
## Overview

Simplification of install.sh, the setup is primarily done via values.yaml. However, I kept the `-t` switch for simplifying the testsuite dependencies installation.

Readme updates and comment updates in values.yaml

Small version updates and using my image rather than mganisin image (not ideal but better).

Introduction of INSTALL_RHCL_GA to simplify the RHCL GA installation.

## Verification Steps

Have a cluster and execute `./install.sh -t`. Kuadrant GA (or whatever you specified in values.yaml) should be successfully installed. Then uninstall via `./uninstall.sh` and do it again, this time install RHCL GA:
`INSTALL_RHCL_GA=false ./install.sh`
