### PR TITLE
Version bumps to OSSM v3 GA and Istio v1.24.3

### DIFF
--- a/instances/templates/ossm3/02-istio.yaml
+++ b/instances/templates/ossm3/02-istio.yaml
@@ -1,5 +1,5 @@
 {{if eq .Values.istio.istioProvider "ossm3"}}
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default

--- a/values.yaml
+++ b/values.yaml
@@ -16,10 +16,10 @@ istio:
   operatorNamespace: istio-system-operator
   istioProvider: ossm3  # need to be set to 'ossm3'
   ossm3: # Openshift Service Mesh, but version 3
-    version: v1.23.0
+    version: v1.24.3
     operator:
-      channel: candidates
-      startingCSV: servicemeshoperator3.v3.0.0-tp.1
+      channel: stable
+      startingCSV: servicemeshoperator3.v3.0.0
       installPlanApproval: Automatic  # if set to Manual InstallPlan has to be approved manually
 
 certManager:


### PR DESCRIPTION
## Overview

Bumping Istio version to v1.24.3 and OSSM v3 to 3.0.0 GA

## Verification Steps

./install.sh
once finished check the Installed Operators. You should see OSSM v3.0.0 from Stable channel installed.