### PR TITLE
Specify controller name via env var for ocp419

### DIFF
--- a/operators/templates/kuadrant/04-subscription.yaml
+++ b/operators/templates/kuadrant/04-subscription.yaml
@@ -18,3 +18,7 @@ spec:
     env:
       - name: "AUTH_SERVICE_TIMEOUT"
         value: "500ms"
+{{- if eq .Values.istio.istioProvider "ocp"}}
+      - name: "ISTIO_GATEWAY_CONTROLLER_NAMES"
+        value: "openshift.io/gateway-controller/v1"
+{{- end}}


### PR DESCRIPTION
## Overview

Controller name has to be specified for Kuadrant operator via ISTIO_GATEWAY_CONTROLLER_NAMES env var. This must be done in Subscription CR - Subscription is the source of truth for CVS, Deployment resources.
This only applies if istioProvider is set to 'ocp'. If OSSM v3 is installed normally (via Operator Hub) this is not needed since correct (default) controller name is used.

For details see https://github.com/Kuadrant/kuadrant-operator/pull/1240

## Verification Steps
Get a OCP v4.19 cluster and install Kuadrant from this PR. Note that if you `./uninstall.sh` first  you need to uninstall OSSM v3 manually. Despite the fact that GatewayClass CR creation triggers OSSM v3 installation its removal does not trigger OSSM v3 uninstallation.