### PR TITLE
Add Valkey and secrets for all databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ helm install --values values.yaml --values additionalManifests.yaml --wait -g op
 ```
 2. Install instances (operands)
 ```sh
-helm install --values values.yaml --values additionalManifests.yaml --wait -g instances/
+helm install --values values.yaml --values additionalManifests.yaml --wait --timeout 10m -g instances/
 ```
 
 # Troubleshooting

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ helm_cmd="helm install --values values.yaml $additional_flags --wait kuadrant-op
 eval "$helm_cmd"
 
 echo "--Installing instances---"
-helm_cmd="helm install --values values.yaml $additional_flags --wait kuadrant-instances instances/"
+helm_cmd="helm install --values values.yaml $additional_flags --wait --timeout 10m kuadrant-instances instances/"
 eval "$helm_cmd"
 
 echo "Success!"

--- a/instances/templates/tools/dragonfly/02-secret.yaml
+++ b/instances/templates/tools/dragonfly/02-secret.yaml
@@ -1,0 +1,11 @@
+{{ if eq .Values.tools.enabled true }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dragonfly-config
+  namespace: {{ .Values.kuadrant.namespace }}
+type: Opaque
+data:
+  # It is redis://dragonfly.tools.svc.cluster.local:6379
+  URL: "cmVkaXM6Ly9kcmFnb25mbHkudG9vbHMuc3ZjLmNsdXN0ZXIubG9jYWw6NjM3OQ=="
+{{- end }}

--- a/instances/templates/tools/redis/02-secret.yaml
+++ b/instances/templates/tools/redis/02-secret.yaml
@@ -1,0 +1,11 @@
+{{ if eq .Values.tools.enabled true }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-config
+  namespace: {{ .Values.kuadrant.namespace }}
+type: Opaque
+data:
+  # It is redis://redis.tools.svc.cluster.local:6379
+  URL: "cmVkaXM6Ly9yZWRpcy50b29scy5zdmMuY2x1c3Rlci5sb2NhbDo2Mzc5"
+{{- end }}

--- a/instances/templates/tools/valkey/00-deployment.yaml
+++ b/instances/templates/tools/valkey/00-deployment.yaml
@@ -1,0 +1,41 @@
+{{ if eq .Values.tools.enabled true }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: valkey
+  name: valkey
+  namespace: {{ .Values.tools.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      containers:
+        - image: {{ .Values.tools.valkey.image }}
+          name: valkey
+          args:
+            - "--maxmemory"
+            - "256mb"
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "10m"
+              memory: "30Mi"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+{{end}}

--- a/instances/templates/tools/valkey/01-service.yaml
+++ b/instances/templates/tools/valkey/01-service.yaml
@@ -1,0 +1,17 @@
+{{ if eq .Values.tools.enabled true }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+  namespace: {{ .Values.tools.namespace }}
+  labels:
+    app: valkey
+spec:
+  selector:
+    app: valkey
+  ports:
+    - name: valkey
+      port: 6379
+      protocol: TCP
+  type: LoadBalancer
+{{end}}

--- a/instances/templates/tools/valkey/02-secret.yaml
+++ b/instances/templates/tools/valkey/02-secret.yaml
@@ -1,0 +1,11 @@
+{{ if eq .Values.tools.enabled true }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: valkey-config
+  namespace: {{ .Values.kuadrant.namespace }}
+type: Opaque
+data:
+  # It is redis://valkey.tools.svc.cluster.local:6379
+  URL: "cmVkaXM6Ly92YWxrZXkudG9vbHMuc3ZjLmNsdXN0ZXIubG9jYWw6NjM3OQ=="
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -65,5 +65,7 @@ tools:
     image: quay.io/opstree/redis:latest
   dragonfly:
     image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+  valkey:
+    image: ghcr.io/valkey-io/valkey:latest
 
 additionalManifests: []


### PR DESCRIPTION
## Overview

In order to consume the databases by Limitador one has to provide a secret. This PR creates such secrets and it also adds Valkey as a drop-in replacement for Redis.
I also increased timeout to 7m, it seems that default 5m is too short due to slow loadbalancers.

## Verification Steps
`./install.sh -t`

Make sure that Valkey pod is present in tools ns, update Limitador CR (leave only one DB in `name`):
```spec:
  storage:
    redis:
      configSecretRef:
        name: redis/dragonfly/valkey-config
```

and trigger some ratelimit policy test (or run smoke tests):
`flags="-vvv" make estsuite/tests/singlecluster/limitador/test_basic_limit.py::test_limit`
